### PR TITLE
Use-buffer-pool

### DIFF
--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -1,0 +1,50 @@
+package nativewebp_test
+
+import (
+	"image"
+	"image/color"
+	"image/draw"
+	"io"
+	"testing"
+
+	"github.com/HugoSmits86/nativewebp"
+)
+
+// image with a simple pattern: white background, black lines, green squares
+var sampleImage = func() image.Image {
+	const size = 500
+
+	// create a white canvas
+	img := image.NewRGBA(image.Rect(0, 0, size, size))
+	draw.Draw(img, img.Bounds(), image.NewUniform(color.White), image.Point{}, draw.Src)
+
+	const squareSize = 10
+	const cellSize = size / 10
+
+	// prepare a green square
+	green := image.NewUniform(color.RGBA{0, 200, 0, 255})
+
+	// put the pattern
+	for x := img.Rect.Min.X; x < img.Rect.Max.X; x++ {
+		for y := img.Rect.Min.Y; y < img.Rect.Max.Y; y++ {
+			if x%cellSize == 0 || y%cellSize == 0 {
+				img.Set(x, y, color.Black)
+			}
+
+			if (x-cellSize/2)%cellSize == 0 && (y-cellSize/2)%cellSize == 0 {
+				draw.Draw(img, image.Rect(x-squareSize, y-squareSize, x, y), green, image.Point{}, draw.Over)
+			}
+		}
+	}
+	return img
+}()
+
+func BenchmarkEncode(b *testing.B) {
+	b.ReportAllocs()
+	for range b.N {
+		err := nativewebp.Encode(io.Discard, sampleImage)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/bitwriter.go
+++ b/bitwriter.go
@@ -1,56 +1,81 @@
 package nativewebp
 
 import (
-    //------------------------------
-    //general
-    //------------------------------
-    "bytes"
+	//------------------------------
+	//general
+	//------------------------------
+	"bytes"
+	"sync"
 )
 
 type bitWriter struct {
-    Buffer          *bytes.Buffer
-    BitBuffer       uint64
-    BitBufferSize   int
+	Buffer        *bytes.Buffer
+	BitBuffer     uint64
+	BitBufferSize int
+}
+
+const maxBitWriterSize = 1 << 20 // 1MB
+
+var bitWriterPool = &sync.Pool{
+	New: func() any {
+		return &bitWriter{Buffer: new(bytes.Buffer)}
+	},
+}
+
+func getBitWriter() *bitWriter {
+	return bitWriterPool.Get().(*bitWriter)
+}
+
+func putBitWriter(w *bitWriter) {
+	if w.Buffer.Cap() > maxBitWriterSize {
+		return
+	}
+
+	w.Buffer.Reset()
+	w.BitBuffer = 0
+	w.BitBufferSize = 0
+
+	bitWriterPool.Put(w)
 }
 
 func (w *bitWriter) writeBits(value uint64, n int) {
-    if n <= 0 || n > 64 {
-        panic("Invalid bit count: must be between 1 and 64")
-    }
+	if n <= 0 || n > 64 {
+		panic("Invalid bit count: must be between 1 and 64")
+	}
 
-    if value >= (1 << n) {
-        panic("too many bits for the given value")
-    }
-    
-    w.BitBuffer |= (value << w.BitBufferSize)
-    w.BitBufferSize += n
-    w.writeThrough()
+	if value >= (1 << n) {
+		panic("too many bits for the given value")
+	}
+
+	w.BitBuffer |= (value << w.BitBufferSize)
+	w.BitBufferSize += n
+	w.writeThrough()
 }
 
 func (w *bitWriter) writeCode(code huffmanCode) {
-    if code.Depth <= 0 {
-        return
-    }
+	if code.Depth <= 0 {
+		return
+	}
 
-    value := uint64(code.Bits)
-    reversed := uint64(0)
-    for i := 0; i < code.Depth; i++ {
-        reversed = (reversed << 1) | (value & 1)
-        value >>= 1
-    }
+	value := uint64(code.Bits)
+	reversed := uint64(0)
+	for i := 0; i < code.Depth; i++ {
+		reversed = (reversed << 1) | (value & 1)
+		value >>= 1
+	}
 
-    w.writeBits(reversed, code.Depth)
+	w.writeBits(reversed, code.Depth)
 }
 
 func (w *bitWriter) AlignByte() {
-    w.BitBufferSize = (w.BitBufferSize + 7) &^ 7
-    w.writeThrough()
+	w.BitBufferSize = (w.BitBufferSize + 7) &^ 7
+	w.writeThrough()
 }
 
 func (w *bitWriter) writeThrough() {
-    for w.BitBufferSize >= 8 {
-        w.Buffer.WriteByte(byte(w.BitBuffer & 0xFF))
-        w.BitBuffer >>= 8
-        w.BitBufferSize -= 8
-    }
+	for w.BitBufferSize >= 8 {
+		w.Buffer.WriteByte(byte(w.BitBuffer & 0xFF))
+		w.BitBuffer >>= 8
+		w.BitBufferSize -= 8
+	}
 }

--- a/writer.go
+++ b/writer.go
@@ -1,488 +1,492 @@
 package nativewebp
 
 import (
-    //------------------------------
-    //general
-    //------------------------------
-    "io"
-    "bytes"
-    "math"
-    "slices"
-    "encoding/binary"
-    //------------------------------
-    //imaging
-    //------------------------------
-    "image"
-    "image/draw"
-    "image/color"
-    //------------------------------
-    //errors
-    //------------------------------
-    //"log"
-    "errors"
+	//------------------------------
+	//general
+	//------------------------------
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"math"
+	"slices"
+
+	//------------------------------
+	//imaging
+	//------------------------------
+	"image"
+	"image/color"
+	"image/draw"
+
+	//------------------------------
+	//errors
+	//------------------------------
+	//"log"
+	"errors"
 )
 
 type transform int
 
 const (
-    transformPredict        = transform(0)
-    transformColor          = transform(1)
-    transformSubGreen       = transform(2)
-    transformColorIndexing  = transform(3)     
+	transformPredict       = transform(0)
+	transformColor         = transform(1)
+	transformSubGreen      = transform(2)
+	transformColorIndexing = transform(3)
 )
 
 func Encode(w io.Writer, img image.Image) error {
-    if img == nil {
-        return errors.New("image is nil")
-    }
+	if img == nil {
+		return errors.New("image is nil")
+	}
 
-    if img.Bounds().Dx() < 1 || img.Bounds().Dy() < 1 {
-        return errors.New("invalid image size")
-    }
+	if img.Bounds().Dx() < 1 || img.Bounds().Dy() < 1 {
+		return errors.New("invalid image size")
+	}
 
-    _, isIndexed := img.(*image.Paletted)
+	_, isIndexed := img.(*image.Paletted)
 
-    rgba := image.NewNRGBA(image.Rect(0, 0, img.Bounds().Dx(), img.Bounds().Dy()))
-    draw.Draw(rgba, rgba.Bounds(), img, img.Bounds().Min, draw.Src)
+	rgba := image.NewNRGBA(image.Rect(0, 0, img.Bounds().Dx(), img.Bounds().Dy()))
+	draw.Draw(rgba, rgba.Bounds(), img, img.Bounds().Min, draw.Src)
 
-    b := &bytes.Buffer{}
-    s := &bitWriter{Buffer: b}
+	s := getBitWriter()
+	defer putBitWriter(s)
 
-    writeBitStreamHeader(s, rgba.Bounds(), !rgba.Opaque())
+	writeBitStreamHeader(s, rgba.Bounds(), !rgba.Opaque())
 
-    var transforms [4]bool
-    transforms[transformPredict] = !isIndexed
-    transforms[transformColor] = false
-    transforms[transformSubGreen] = !isIndexed
-    transforms[transformColorIndexing] = isIndexed
+	var transforms [4]bool
+	transforms[transformPredict] = !isIndexed
+	transforms[transformColor] = false
+	transforms[transformSubGreen] = !isIndexed
+	transforms[transformColorIndexing] = isIndexed
 
-    err := writeBitStreamData(s, rgba, 4, transforms)
-    if err != nil {
-        return err
-    }
-    
-    s.AlignByte()
+	err := writeBitStreamData(s, rgba, 4, transforms)
+	if err != nil {
+		return err
+	}
 
-    if b.Len() % 2 != 0 {
-        b.Write([]byte{0x00})
-    }
+	s.AlignByte()
 
-    writeWebPHeader(w, b)
+	if s.Buffer.Len()%2 != 0 {
+		s.Buffer.Write([]byte{0x00})
+	}
 
-    data := b.Bytes()
-    w.Write(data)
+	writeWebPHeader(w, s.Buffer)
 
-    return nil
+	if _, err := s.Buffer.WriteTo(w); err != nil {
+		return fmt.Errorf("writing data: %w", err)
+	}
+
+	return nil
 }
 
 func writeWebPHeader(w io.Writer, b *bytes.Buffer) {
-    w.Write([]byte("RIFF"))
+	w.Write([]byte("RIFF"))
 
-    tmp := make([]byte, 4)
-    binary.LittleEndian.PutUint32(tmp, uint32(12 + b.Len()))
-    w.Write(tmp)
+	tmp := make([]byte, 4)
+	binary.LittleEndian.PutUint32(tmp, uint32(12+b.Len()))
+	w.Write(tmp)
 
-    w.Write([]byte("WEBP"))
-    w.Write([]byte("VP8L"))
+	w.Write([]byte("WEBP"))
+	w.Write([]byte("VP8L"))
 
-    tmp = make([]byte, 4)
-    binary.LittleEndian.PutUint32(tmp, uint32(b.Len()))
-    w.Write(tmp)
+	tmp = make([]byte, 4)
+	binary.LittleEndian.PutUint32(tmp, uint32(b.Len()))
+	w.Write(tmp)
 }
 
 func writeBitStreamHeader(w *bitWriter, bounds image.Rectangle, hasAlpha bool) {
-    w.writeBits(0x2f, 8)
+	w.writeBits(0x2f, 8)
 
-    w.writeBits(uint64(bounds.Dx() - 1), 14)
-    w.writeBits(uint64(bounds.Dy() - 1), 14)
+	w.writeBits(uint64(bounds.Dx()-1), 14)
+	w.writeBits(uint64(bounds.Dy()-1), 14)
 
-    if hasAlpha {
-        w.writeBits(1, 1)
-    } else {
-        w.writeBits(0, 1)
-    }
+	if hasAlpha {
+		w.writeBits(1, 1)
+	} else {
+		w.writeBits(0, 1)
+	}
 
-    w.writeBits(0, 3)
+	w.writeBits(0, 3)
 }
 
 func writeBitStreamData(w *bitWriter, img image.Image, colorCacheBits int, transforms [4]bool) error {
-    pixels, err := flatten(img)
-    if err != nil {
-        return err
-    }
+	pixels, err := flatten(img)
+	if err != nil {
+		return err
+	}
 
-    if transforms[transformColorIndexing] {
-        w.writeBits(1, 1)
-        w.writeBits(3, 2)
-       
-        pal, err := applyPalettetransform(pixels)
-        if err != nil {
-            return err
-        }
-       
-        w.writeBits(uint64(len(pal) - 1), 8);
-        writeImageData(w, pal, false, colorCacheBits);
-    }
+	if transforms[transformColorIndexing] {
+		w.writeBits(1, 1)
+		w.writeBits(3, 2)
 
-    if transforms[transformSubGreen] {
-        w.writeBits(1, 1)
-        w.writeBits(2, 2)
+		pal, err := applyPalettetransform(pixels)
+		if err != nil {
+			return err
+		}
 
-        applySubtractGreentransform(pixels)
-    }
+		w.writeBits(uint64(len(pal)-1), 8)
+		writeImageData(w, pal, false, colorCacheBits)
+	}
 
-    if transforms[transformColor] {
-        w.writeBits(1, 1)
-        w.writeBits(1, 2)
+	if transforms[transformSubGreen] {
+		w.writeBits(1, 1)
+		w.writeBits(2, 2)
 
-        bits, blocks := applyColortransform(pixels, img.Bounds().Dx(), img.Bounds().Dy())
+		applySubtractGreentransform(pixels)
+	}
 
-        w.writeBits(uint64(bits - 2), 3);
-        writeImageData(w, blocks, false, colorCacheBits)
-    }
+	if transforms[transformColor] {
+		w.writeBits(1, 1)
+		w.writeBits(1, 2)
 
-    if transforms[transformPredict] {
-        w.writeBits(1, 1)
-        w.writeBits(0, 2)
+		bits, blocks := applyColortransform(pixels, img.Bounds().Dx(), img.Bounds().Dy())
 
-        bits, blocks := applyPredicttransform(pixels, img.Bounds().Dx(), img.Bounds().Dy())
+		w.writeBits(uint64(bits-2), 3)
+		writeImageData(w, blocks, false, colorCacheBits)
+	}
 
-        w.writeBits(uint64(bits - 2), 3);
-        writeImageData(w, blocks, false, colorCacheBits)
-    }
+	if transforms[transformPredict] {
+		w.writeBits(1, 1)
+		w.writeBits(0, 2)
 
-    w.writeBits(0, 1) // end of transform
-    writeImageData(w, pixels, true, colorCacheBits)
+		bits, blocks := applyPredicttransform(pixels, img.Bounds().Dx(), img.Bounds().Dy())
 
-    return nil
+		w.writeBits(uint64(bits-2), 3)
+		writeImageData(w, blocks, false, colorCacheBits)
+	}
+
+	w.writeBits(0, 1) // end of transform
+	writeImageData(w, pixels, true, colorCacheBits)
+
+	return nil
 }
 
 func writeImageData(w *bitWriter, pixels []color.NRGBA, isRecursive bool, colorCacheBits int) {
-    if colorCacheBits > 0 {
-        w.writeBits(1, 1)
-        w.writeBits(uint64(colorCacheBits), 4) 
-    } else {
-        w.writeBits(0, 1)
-    }
+	if colorCacheBits > 0 {
+		w.writeBits(1, 1)
+		w.writeBits(uint64(colorCacheBits), 4)
+	} else {
+		w.writeBits(0, 1)
+	}
 
-    if isRecursive {
-        w.writeBits(0, 1)
-    }
+	if isRecursive {
+		w.writeBits(0, 1)
+	}
 
-    encoded := encodeImageData(pixels, colorCacheBits)
-    histos := computeHistograms(encoded, colorCacheBits)
+	encoded := encodeImageData(pixels, colorCacheBits)
+	histos := computeHistograms(encoded, colorCacheBits)
 
-    var codes [][]huffmanCode
-    for i := 0; i < 5; i++ {
-        c := buildhuffmanCodes(histos[i], 16)
-        codes = append(codes, c)
+	var codes [][]huffmanCode
+	for i := 0; i < 5; i++ {
+		c := buildhuffmanCodes(histos[i], 16)
+		codes = append(codes, c)
 
-        writehuffmanCodes(w, c)
-    }
+		writehuffmanCodes(w, c)
+	}
 
-    for i := 0; i < len(encoded); i ++ {
-        w.writeCode(codes[0][encoded[i + 0]])
-        if encoded[i + 0] < 256 {
-            w.writeCode(codes[1][encoded[i + 1]])
-            w.writeCode(codes[2][encoded[i + 2]])
-            w.writeCode(codes[3][encoded[i + 3]])
-            i += 3
-        }
-    }
+	for i := 0; i < len(encoded); i++ {
+		w.writeCode(codes[0][encoded[i+0]])
+		if encoded[i+0] < 256 {
+			w.writeCode(codes[1][encoded[i+1]])
+			w.writeCode(codes[2][encoded[i+2]])
+			w.writeCode(codes[3][encoded[i+3]])
+			i += 3
+		}
+	}
 }
 
 func encodeImageData(pixels []color.NRGBA, colorCacheBits int) []uint16 {
-    cache := make([]color.NRGBA, 1 << colorCacheBits)
-    encoded := make([]uint16, len(pixels) * 4)
+	cache := make([]color.NRGBA, 1<<colorCacheBits)
+	encoded := make([]uint16, len(pixels)*4)
 
-    cnt := 0
-    for _, p := range pixels {
-        hash := 0
-        if colorCacheBits > 0 {
-            //hash formula including magic number 0x1e35a7bd comes directly from WebP specs!
-            pack := uint32(p.A) << 24 | uint32(p.R) << 16 | uint32(p.G) << 8 | uint32(p.B)
-            hash = int((pack * 0x1e35a7bd) >> (32 - colorCacheBits))
+	cnt := 0
+	for _, p := range pixels {
+		hash := 0
+		if colorCacheBits > 0 {
+			//hash formula including magic number 0x1e35a7bd comes directly from WebP specs!
+			pack := uint32(p.A)<<24 | uint32(p.R)<<16 | uint32(p.G)<<8 | uint32(p.B)
+			hash = int((pack * 0x1e35a7bd) >> (32 - colorCacheBits))
 
-            if cache[hash] == p {
-                encoded[cnt] = uint16(hash + 256 + 24)
-                cnt++
-                continue
-            }
+			if cache[hash] == p {
+				encoded[cnt] = uint16(hash + 256 + 24)
+				cnt++
+				continue
+			}
 
-            cache[hash] = p
-        }
+			cache[hash] = p
+		}
 
-        encoded[cnt + 0] = uint16(p.G)
-        encoded[cnt + 1] = uint16(p.R)
-        encoded[cnt + 2] = uint16(p.B)
-        encoded[cnt + 3] = uint16(p.A)
-        cnt += 4
-    }
+		encoded[cnt+0] = uint16(p.G)
+		encoded[cnt+1] = uint16(p.R)
+		encoded[cnt+2] = uint16(p.B)
+		encoded[cnt+3] = uint16(p.A)
+		cnt += 4
+	}
 
-    return encoded[:cnt]
+	return encoded[:cnt]
 }
 
 func computeHistograms(pixels []uint16, colorCacheBits int) [][]int {
-    c := 0
-    if colorCacheBits > 0 {
-        c = 1 << colorCacheBits
-    }
+	c := 0
+	if colorCacheBits > 0 {
+		c = 1 << colorCacheBits
+	}
 
-    histos := [][]int{
-        make([]int, 256 + 24 + c),
-        make([]int, 256),
-        make([]int, 256),
-        make([]int, 256),
-        make([]int, 40),
-    }
+	histos := [][]int{
+		make([]int, 256+24+c),
+		make([]int, 256),
+		make([]int, 256),
+		make([]int, 256),
+		make([]int, 40),
+	}
 
-    for i := 0; i < len(pixels); i++ {
-        histos[0][pixels[i]]++
-        if(pixels[i] < 256) {
-            histos[1][pixels[i + 1]]++
-            histos[2][pixels[i + 2]]++
-            histos[3][pixels[i + 3]]++
-            i += 3
-        }
-    }
+	for i := 0; i < len(pixels); i++ {
+		histos[0][pixels[i]]++
+		if pixels[i] < 256 {
+			histos[1][pixels[i+1]]++
+			histos[2][pixels[i+2]]++
+			histos[3][pixels[i+3]]++
+			i += 3
+		}
+	}
 
-    return histos
+	return histos
 }
 
 func flatten(img image.Image) ([]color.NRGBA, error) {
-    w := img.Bounds().Dx()
-    h := img.Bounds().Dy()
+	w := img.Bounds().Dx()
+	h := img.Bounds().Dy()
 
-    rgba, ok := img.(*image.NRGBA)
-    if !ok {
-        return nil, errors.New("unsupported image format")
-    }
+	rgba, ok := img.(*image.NRGBA)
+	if !ok {
+		return nil, errors.New("unsupported image format")
+	}
 
-    pixels := make([]color.NRGBA, w * h)
-    for y := 0; y < h; y++ {
-        for x := 0; x < w; x++ {
-            i := rgba.PixOffset(x, y)
-            s := rgba.Pix[i : i + 4 : i + 4]
+	pixels := make([]color.NRGBA, w*h)
+	for y := 0; y < h; y++ {
+		for x := 0; x < w; x++ {
+			i := rgba.PixOffset(x, y)
+			s := rgba.Pix[i : i+4 : i+4]
 
-            pixels[y * w + x].R = uint8(s[0])
-            pixels[y * w + x].G = uint8(s[1])
-            pixels[y * w + x].B = uint8(s[2])
-            pixels[y * w + x].A = uint8(s[3])
-        }
-    }
+			pixels[y*w+x].R = uint8(s[0])
+			pixels[y*w+x].G = uint8(s[1])
+			pixels[y*w+x].B = uint8(s[2])
+			pixels[y*w+x].A = uint8(s[3])
+		}
+	}
 
-    return pixels, nil
+	return pixels, nil
 }
 
 func applyPredicttransform(pixels []color.NRGBA, width, height int) (int, []color.NRGBA) {
-    tileBits := 4
-    tileSize := 1 << tileBits
-    bw := (width + tileSize - 1) / tileSize
-    bh := (height + tileSize - 1) / tileSize
+	tileBits := 4
+	tileSize := 1 << tileBits
+	bw := (width + tileSize - 1) / tileSize
+	bh := (height + tileSize - 1) / tileSize
 
-    blocks := make([]color.NRGBA, bw * bh)
-    deltas := make([]color.NRGBA, width * height)
-    
-    //TODO: analyze block and pick best filter
-    best := 1
-    for y := 0; y < bh; y++ {
-        for x := 0; x < bw; x++ {
-            mx := min((x + 1) << tileBits, width)
-            my := min((y + 1) << tileBits, height)
+	blocks := make([]color.NRGBA, bw*bh)
+	deltas := make([]color.NRGBA, width*height)
 
-            for tx := x << tileBits; tx < mx; tx++ {
-                for ty := y << tileBits; ty < my; ty++ {
-                    d := applyFilter(pixels, width, tx, ty, best)
-                    
-                    off := ty * width + tx
-                    deltas[off] = color.NRGBA{
-                        R: uint8(pixels[off].R - d.R),
-                        G: uint8(pixels[off].G - d.G),
-                        B: uint8(pixels[off].B - d.B),
-                        A: uint8(pixels[off].A - d.A),
-                    }
-                }
-            }
+	//TODO: analyze block and pick best filter
+	best := 1
+	for y := 0; y < bh; y++ {
+		for x := 0; x < bw; x++ {
+			mx := min((x+1)<<tileBits, width)
+			my := min((y+1)<<tileBits, height)
 
-            blocks[y * bw + x] = color.NRGBA{0, byte(best), 0, 255}
-        }
-    }
-    
-    copy(pixels, deltas)
-    
-    return tileBits, blocks
+			for tx := x << tileBits; tx < mx; tx++ {
+				for ty := y << tileBits; ty < my; ty++ {
+					d := applyFilter(pixels, width, tx, ty, best)
+
+					off := ty*width + tx
+					deltas[off] = color.NRGBA{
+						R: uint8(pixels[off].R - d.R),
+						G: uint8(pixels[off].G - d.G),
+						B: uint8(pixels[off].B - d.B),
+						A: uint8(pixels[off].A - d.A),
+					}
+				}
+			}
+
+			blocks[y*bw+x] = color.NRGBA{0, byte(best), 0, 255}
+		}
+	}
+
+	copy(pixels, deltas)
+
+	return tileBits, blocks
 }
 
 func applyFilter(pixels []color.NRGBA, width, x, y, prediction int) color.NRGBA {
-    if x == 0 && y == 0 {
-        return color.NRGBA{0, 0, 0, 255}
-    } else if x == 0 {
-        return pixels[(y - 1) * width + x]
-    } else if y == 0 {
-        return pixels[y * width + (x - 1)]
-    }
-    
-    t := pixels[(y - 1) * width + x]
-    l := pixels[y * width + (x - 1)]
+	if x == 0 && y == 0 {
+		return color.NRGBA{0, 0, 0, 255}
+	} else if x == 0 {
+		return pixels[(y-1)*width+x]
+	} else if y == 0 {
+		return pixels[y*width+(x-1)]
+	}
 
-    tl := pixels[(y - 1) * width + (x - 1)]
-    tr := pixels[(y - 1) * width + (x + 1)]
+	t := pixels[(y-1)*width+x]
+	l := pixels[y*width+(x-1)]
 
-    avarage2 := func(a, b color.NRGBA) color.NRGBA {
-        return color.NRGBA {
-            uint8((int(a.R) + int(b.R)) / 2), 
-            uint8((int(a.G) + int(b.G)) / 2),  
-            uint8((int(a.B) + int(b.B)) / 2),  
-            uint8((int(a.A) + int(b.A)) / 2),
-        }
-    }
+	tl := pixels[(y-1)*width+(x-1)]
+	tr := pixels[(y-1)*width+(x+1)]
 
-    filters := []func(t, l, tl, tr color.NRGBA) color.NRGBA {
-        func(t, l, tl, tr color.NRGBA) color.NRGBA { return color.NRGBA{0, 0, 0, 255} },
-        func(t, l, tl, tr color.NRGBA) color.NRGBA { return l },
-        func(t, l, tl, tr color.NRGBA) color.NRGBA { return t },
-        func(t, l, tl, tr color.NRGBA) color.NRGBA { return tr },
-        func(t, l, tl, tr color.NRGBA) color.NRGBA { return tl },
-        func(t, l, tl, tr color.NRGBA) color.NRGBA {
-            return avarage2(avarage2(l, tr), t)
-        },
-        func(t, l, tl, tr color.NRGBA) color.NRGBA {
-            return avarage2(l, tl)
-        },
-        func(t, l, tl, tr color.NRGBA) color.NRGBA {
-            return avarage2(l, t)
-        },
-        func(t, l, tl, tr color.NRGBA) color.NRGBA {
-            return avarage2(tl, t)
-        },
-        func(t, l, tl, tr color.NRGBA) color.NRGBA {
-            return avarage2(t, tr)
-        },
-        func(t, l, tl, tr color.NRGBA) color.NRGBA {
-            return avarage2(avarage2(l, tl), avarage2(t, tr))
-        },
-        func(t, l, tl, tr color.NRGBA) color.NRGBA { 
-            pr := float64(l.R) + float64(t.R) - float64(tl.R)
-            pg := float64(l.G) + float64(t.G) - float64(tl.G)
-            pb := float64(l.B) + float64(t.B) - float64(tl.B)
-            pa := float64(l.A) + float64(t.A) - float64(tl.A)
+	avarage2 := func(a, b color.NRGBA) color.NRGBA {
+		return color.NRGBA{
+			uint8((int(a.R) + int(b.R)) / 2),
+			uint8((int(a.G) + int(b.G)) / 2),
+			uint8((int(a.B) + int(b.B)) / 2),
+			uint8((int(a.A) + int(b.A)) / 2),
+		}
+	}
 
-            // Manhattan distances to estimates for left and top pixels.
-            pl := math.Abs(pa - float64(l.A)) + math.Abs(pr - float64(l.R)) + 
-                  math.Abs(pg - float64(l.G)) + math.Abs(pb - float64(l.B))
-            pt := math.Abs(pa - float64(t.A)) + math.Abs(pr - float64(t.R)) + 
-                  math.Abs(pg - float64(t.G)) + math.Abs(pb - float64(t.B))
+	filters := []func(t, l, tl, tr color.NRGBA) color.NRGBA{
+		func(t, l, tl, tr color.NRGBA) color.NRGBA { return color.NRGBA{0, 0, 0, 255} },
+		func(t, l, tl, tr color.NRGBA) color.NRGBA { return l },
+		func(t, l, tl, tr color.NRGBA) color.NRGBA { return t },
+		func(t, l, tl, tr color.NRGBA) color.NRGBA { return tr },
+		func(t, l, tl, tr color.NRGBA) color.NRGBA { return tl },
+		func(t, l, tl, tr color.NRGBA) color.NRGBA {
+			return avarage2(avarage2(l, tr), t)
+		},
+		func(t, l, tl, tr color.NRGBA) color.NRGBA {
+			return avarage2(l, tl)
+		},
+		func(t, l, tl, tr color.NRGBA) color.NRGBA {
+			return avarage2(l, t)
+		},
+		func(t, l, tl, tr color.NRGBA) color.NRGBA {
+			return avarage2(tl, t)
+		},
+		func(t, l, tl, tr color.NRGBA) color.NRGBA {
+			return avarage2(t, tr)
+		},
+		func(t, l, tl, tr color.NRGBA) color.NRGBA {
+			return avarage2(avarage2(l, tl), avarage2(t, tr))
+		},
+		func(t, l, tl, tr color.NRGBA) color.NRGBA {
+			pr := float64(l.R) + float64(t.R) - float64(tl.R)
+			pg := float64(l.G) + float64(t.G) - float64(tl.G)
+			pb := float64(l.B) + float64(t.B) - float64(tl.B)
+			pa := float64(l.A) + float64(t.A) - float64(tl.A)
 
-            if pl < pt {
-                return l
-            }
+			// Manhattan distances to estimates for left and top pixels.
+			pl := math.Abs(pa-float64(l.A)) + math.Abs(pr-float64(l.R)) +
+				math.Abs(pg-float64(l.G)) + math.Abs(pb-float64(l.B))
+			pt := math.Abs(pa-float64(t.A)) + math.Abs(pr-float64(t.R)) +
+				math.Abs(pg-float64(t.G)) + math.Abs(pb-float64(t.B))
 
-            return t
-        },
-        func(t, l, tl, tr color.NRGBA) color.NRGBA {
-            return color.NRGBA{
-                uint8(max(min(int(l.R) + int(t.R) - int(tl.R), 255), 0)),
-                uint8(max(min(int(l.G) + int(t.G) - int(tl.G), 255), 0)),
-                uint8(max(min(int(l.B) + int(t.B) - int(tl.B), 255), 0)),
-                uint8(max(min(int(l.A) + int(t.A) - int(tl.A), 255), 0)),
-            }
-        },
-        func(t, l, tl, tr color.NRGBA) color.NRGBA {
-            a := avarage2(l, t)
+			if pl < pt {
+				return l
+			}
 
-            return color.NRGBA{
-                uint8(max(min(int(a.R) + (int(a.R) - int(tl.R)) / 2, 255), 0)),
-                uint8(max(min(int(a.G) + (int(a.G) - int(tl.G)) / 2, 255), 0)),
-                uint8(max(min(int(a.B) + (int(a.B) - int(tl.B)) / 2, 255), 0)),
-                uint8(max(min(int(a.A) + (int(a.A) - int(tl.A)) / 2, 255), 0)),
-            }
-        },
-    }
-    
-    return filters[prediction](t, l, tl, tr)
+			return t
+		},
+		func(t, l, tl, tr color.NRGBA) color.NRGBA {
+			return color.NRGBA{
+				uint8(max(min(int(l.R)+int(t.R)-int(tl.R), 255), 0)),
+				uint8(max(min(int(l.G)+int(t.G)-int(tl.G), 255), 0)),
+				uint8(max(min(int(l.B)+int(t.B)-int(tl.B), 255), 0)),
+				uint8(max(min(int(l.A)+int(t.A)-int(tl.A), 255), 0)),
+			}
+		},
+		func(t, l, tl, tr color.NRGBA) color.NRGBA {
+			a := avarage2(l, t)
+
+			return color.NRGBA{
+				uint8(max(min(int(a.R)+(int(a.R)-int(tl.R))/2, 255), 0)),
+				uint8(max(min(int(a.G)+(int(a.G)-int(tl.G))/2, 255), 0)),
+				uint8(max(min(int(a.B)+(int(a.B)-int(tl.B))/2, 255), 0)),
+				uint8(max(min(int(a.A)+(int(a.A)-int(tl.A))/2, 255), 0)),
+			}
+		},
+	}
+
+	return filters[prediction](t, l, tl, tr)
 }
 
 func applyColortransform(pixels []color.NRGBA, width, height int) (int, []color.NRGBA) {
-    tileBits := 4
-    tileSize := 1 << tileBits
-    bw := (width + tileSize - 1) / tileSize
-    bh := (height + tileSize - 1) / tileSize
+	tileBits := 4
+	tileSize := 1 << tileBits
+	bw := (width + tileSize - 1) / tileSize
+	bh := (height + tileSize - 1) / tileSize
 
-    blocks := make([]color.NRGBA, bw * bh)
-    deltas := make([]color.NRGBA, width * height)
-    
-    //TODO: analyze block and pick best Color transform Element (CTE)
-    cte := color.NRGBA {
-        R: 1,   //red to blue
-        G: 2,   //green to blue
-        B: 3,   //green to red
-        A: 255,
-    }
-    
-    for y := 0; y < bh; y++ {
-        for x := 0; x < bw; x++ {
-            mx := min((x + 1) << tileBits, width)
-            my := min((y + 1) << tileBits, height)
+	blocks := make([]color.NRGBA, bw*bh)
+	deltas := make([]color.NRGBA, width*height)
 
-            for tx := x << tileBits; tx < mx; tx++ {
-                for ty := y << tileBits; ty < my; ty++ {
-                    off := ty * width + tx
+	//TODO: analyze block and pick best Color transform Element (CTE)
+	cte := color.NRGBA{
+		R: 1, //red to blue
+		G: 2, //green to blue
+		B: 3, //green to red
+		A: 255,
+	}
 
-                    r := int(int8(pixels[off].R))
-                    g := int(int8(pixels[off].G))
-                    b := int(int8(pixels[off].B))
-                
-                    b -= int(int8((int16(int8(cte.G)) * int16(g)) >> 5))
-                    b -= int(int8((int16(int8(cte.R)) * int16(r)) >> 5))
-                    r -= int(int8((int16(int8(cte.B)) * int16(g)) >> 5))
-                    
-                    pixels[off].R = uint8(r & 0xff)
-                    pixels[off].B = uint8(b & 0xff)
+	for y := 0; y < bh; y++ {
+		for x := 0; x < bw; x++ {
+			mx := min((x+1)<<tileBits, width)
+			my := min((y+1)<<tileBits, height)
 
-                    deltas[off] = pixels[off]
-                }
-            }
+			for tx := x << tileBits; tx < mx; tx++ {
+				for ty := y << tileBits; ty < my; ty++ {
+					off := ty*width + tx
 
-            blocks[y * bw + x] = cte
-        }
-    }
-    
-    copy(pixels, deltas)
-    
-    return tileBits, blocks
+					r := int(int8(pixels[off].R))
+					g := int(int8(pixels[off].G))
+					b := int(int8(pixels[off].B))
+
+					b -= int(int8((int16(int8(cte.G)) * int16(g)) >> 5))
+					b -= int(int8((int16(int8(cte.R)) * int16(r)) >> 5))
+					r -= int(int8((int16(int8(cte.B)) * int16(g)) >> 5))
+
+					pixels[off].R = uint8(r & 0xff)
+					pixels[off].B = uint8(b & 0xff)
+
+					deltas[off] = pixels[off]
+				}
+			}
+
+			blocks[y*bw+x] = cte
+		}
+	}
+
+	copy(pixels, deltas)
+
+	return tileBits, blocks
 }
 
 func applySubtractGreentransform(pixels []color.NRGBA) {
-    for i, _ := range pixels {
-        pixels[i].R = pixels[i].R - pixels[i].G
-        pixels[i].B = pixels[i].B - pixels[i].G
-    }
+	for i, _ := range pixels {
+		pixels[i].R = pixels[i].R - pixels[i].G
+		pixels[i].B = pixels[i].B - pixels[i].G
+	}
 }
 
 func applyPalettetransform(pixels []color.NRGBA) ([]color.NRGBA, error) {
-    var pal []color.NRGBA
-    for _, p := range pixels {
-        if !slices.Contains(pal, p) {
-            pal = append(pal, p)
-        }
-   
-        if len(pal) > 256 {
-            return nil, errors.New("palette exceeds 256 colors")
-        }
-    }
-   
-    for i, p := range pixels {
-        pixels[i] = color.NRGBA{G: uint8(slices.Index(pal, p)), A: 255}
-    }
-   
-    for i := len(pal) - 1; i > 0; i-- {
-        pal[i] = color.NRGBA{
-            R: pal[i].R - pal[i - 1].R,
-            G: pal[i].G - pal[i - 1].G,
-            B: pal[i].B - pal[i - 1].B,
-            A: pal[i].A - pal[i - 1].A,
-        }
-    }
-   
-    return pal, nil
+	var pal []color.NRGBA
+	for _, p := range pixels {
+		if !slices.Contains(pal, p) {
+			pal = append(pal, p)
+		}
+
+		if len(pal) > 256 {
+			return nil, errors.New("palette exceeds 256 colors")
+		}
+	}
+
+	for i, p := range pixels {
+		pixels[i] = color.NRGBA{G: uint8(slices.Index(pal, p)), A: 255}
+	}
+
+	for i := len(pal) - 1; i > 0; i-- {
+		pal[i] = color.NRGBA{
+			R: pal[i].R - pal[i-1].R,
+			G: pal[i].G - pal[i-1].G,
+			B: pal[i].B - pal[i-1].B,
+			A: pal[i].A - pal[i-1].A,
+		}
+	}
+
+	return pal, nil
 }


### PR DESCRIPTION
Hello!
Thank you for you library, I was eager to have a proper native webp encoder for golang

This will allow to decrease number of allocations by reusing existing buffer

Profiles and benchmarking:
```
goos: darwin
goarch: arm64
pkg: github.com/HugoSmits86/nativewebp
cpu: Apple M1

without pool:
BenchmarkEncode-8   	     171	   6581152 ns/op	 5256600 B/op	     215 allocs/op

with pool:
BenchmarkEncode-8   	     172	   6568890 ns/op	 5126767 B/op	     206 allocs/op
```