### PR TITLE
added decoder & unit tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/HugoSmits86/nativewebp
 
 go 1.22.2
+
+require golang.org/x/image v0.24.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+golang.org/x/image v0.24.0 h1:AN7zRgVsbvmTfNyqIbbOraYL8mSwcKncEj8ofjgzcMQ=
+golang.org/x/image v0.24.0/go.mod h1:4b/ITuLfqYq1hqZcjofwctIhi7sZh2WaCjvsBNjjya8=

--- a/writer.go
+++ b/writer.go
@@ -18,8 +18,12 @@ import (
     //------------------------------
     //"log"
     "errors"
+    wp "golang.org/x/image/webp"
 )
-
+// registers the webp decoder so image.Decode can detect and use it.
+func init() {
+	image.RegisterFormat("webp", "RIFF", Decode, DecodeConfig)
+}
 // Options holds future configuration settings (e.g., compression levels)
 type Options struct {
 }
@@ -79,6 +83,14 @@ func Encode(w io.Writer, img image.Image, o *Options) error {
     w.Write(data)
 
     return nil
+}
+
+func Decode(r io.Reader) (image.Image, error) {
+	return wp.Decode(r)
+}
+
+func DecodeConfig(r io.Reader) (image.Config, error) {
+	return wp.DecodeConfig(r)
 }
 
 func writeWebPHeader(w io.Writer, b *bytes.Buffer) {


### PR DESCRIPTION
## Changes

Added  https://pkg.go.dev/golang.org/x/image/webp as the webp decoder. It is registered automatically inside the `init()` when the package is imported. This makes it work out of the box with the `image.Decode(file)` of the standard library.

Added wrappers for `Decode()` and `DecodeConfig()` to decode images directly through the package.

### Unit tests

Created 2 helper functions `toNRGBA` and `imagesEqual` the latter of which just compares 2 `*image.NRGBA` pixel-pixel

- Added unit tests for testing the decode & decodeConfig function 
- Added unit test to make sure that the decoder gets automatically registered and `image.Decode()` from the standard  library uses the decoder.
- Added unit test to make sure an error is thrown when attempting to decode invalid data.

Closes #7